### PR TITLE
Colorize console output

### DIFF
--- a/bin/thingssdk.js
+++ b/bin/thingssdk.js
@@ -10,6 +10,14 @@ const readLine = require("readline").createInterface({
     input: process.stdin,
     output: process.stdout
 });
+const colors = require("colors");
+colors.setTheme({
+    info: "green",
+    help: "cyan",
+    warn: "yellow",
+    debug: "blue",
+    error: "red"
+});
 
 const argv = require("yargs")
     .version(cliPackage.version)
@@ -45,17 +53,17 @@ Would you like to overwrite the existing files?
 Type y or n: `, (answer) => {
                 switch (answer.toLowerCase().trim()) {
                     case ("y" || "yes"):
-                        console.log("Answered 'yes'. Overwriting existing project files.");
+                        console.log(colors.info("You answered yes. Overwriting existing project files."));
                         readLine.close();
                         createFiles(destinationPath, applicationFinished(destinationPath));
                         break;
                     case ("n" || "no"):
-                        console.log("No project files were changed. Aborting new project creation.");
+                        console.log(colors.warn("No project files were changed. Aborting new project creation."));
                         readLine.close();
                         process.exit(1);
                         break;
                     default:
-                        console.error("I don't understand your input. No project files were changed. Aborting new project creation.");
+                        console.error(colors.error("I don't understand your input. No project files were changed. Aborting new project creation."));
                         readLine.close();
                         process.exit(1);
                 }
@@ -66,9 +74,11 @@ Type y or n: `, (answer) => {
 
 function applicationFinished(destinationPath) {
     return (err) => {
-	    if (err) throw err;
-	    console.log(`To install the project dependencies:\n\tcd ${destinationPath} && npm install`);
-	    console.log(`To upload to your device:\n\tcd ${destinationPath} && npm run push`);
+        if (err) throw err;
+        console.log(colors.help(`To install the project dependencies:
+    cd ${destinationPath} && npm install
+To upload to your device:
+    cd ${destinationPath} && npm run push`));
         process.exit(0);
     };
 }

--- a/bin/thingssdk.js
+++ b/bin/thingssdk.js
@@ -69,6 +69,7 @@ function applicationFinished(destinationPath) {
 	    if (err) throw err;
 	    console.log(`To install the project dependencies:\n\tcd ${destinationPath} && npm install`);
 	    console.log(`To upload to your device:\n\tcd ${destinationPath} && npm run push`);
+        process.exit(0);
     };
 }
 

--- a/bin/thingssdk.js
+++ b/bin/thingssdk.js
@@ -6,6 +6,10 @@ const fs = require("fs");
 const mkdirp = require("mkdirp");
 const cliPackage = require("../package.json");
 const exec = require("child_process").exec;
+const readLine = require("readline").createInterface({
+    input: process.stdin,
+    output: process.stdout
+});
 
 const argv = require("yargs")
     .version(cliPackage.version)
@@ -35,14 +39,27 @@ function createApplication(destinationPath) {
     isDirectoryEmpty(destinationPath, (isEmpty) => {
         if (isEmpty) {
             createFiles(destinationPath, applicationFinished(destinationPath));
-        } else {
-            //TODO Confirm if user wants to overwrite
-            if(false) {
-                console.error("No project files were changed.");
-                process.exit(1);
-            } else {
-                createFiles(destinationPath, applicationFinished(destinationPath));
-            }
+        } else if (!isEmpty) {
+            readLine.question(`Files already exist at ${destinationPath}.
+Would you like to overwrite the existing files?
+Type y or n: `, (answer) => {
+                switch (answer.toLowerCase().trim()) {
+                    case ("y" || "yes"):
+                        console.log("Answered 'yes'. Overwriting existing project files.");
+                        readLine.close();
+                        createFiles(destinationPath, applicationFinished(destinationPath));
+                        break;
+                    case ("n" || "no"):
+                        console.log("No project files were changed. Aborting new project creation.");
+                        readLine.close();
+                        process.exit(1);
+                        break;
+                    default:
+                        console.error("I don't understand your input. No project files were changed. Aborting new project creation.");
+                        readLine.close();
+                        process.exit(1);
+                }
+            });
         }
     });
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/thingsSDK/thingssdk-cli#readme",
   "dependencies": {
+    "colors": "^1.1.2",
     "mkdirp": "^0.5.1",
     "yargs": "^4.7.1"
   }


### PR DESCRIPTION
A starting point for #8. I see improving the CLI experience as an ongoing project. This is just an introduction that adds some fundamental scaffolding / coloring to the main script.

I've chosen [`npm colors`](https://www.npmjs.com/package/colors) just because I've worked with it before, but if another package like [`npm chalk`](https://www.npmjs.com/package/chalk) is better, that swap can be made.

This PR also prefers upfront configuration to distributed choices in output UI. For example:

``` javascript
// line 14
colors.setTheme({
    info: "green",
    help: "cyan",
    warn: "yellow",
    debug: "blue",
    error: "red"
});

// line 56
console.log(colors.info("You answered yes. Overwriting existing project files."));
```

As opposed to:

``` javascript
// line 14

// line 56
console.log(colors.green("You answered yes..."));
```
