### PR TITLE
Adds npm run repl

### DIFF
--- a/lib/new.js
+++ b/lib/new.js
@@ -113,7 +113,8 @@ function createPackageJSON(app_name, runtime) {
         private: true,
         main: 'main.js',
         scripts: {
-            push: "node ./scripts/push"
+            push: "node ./scripts/push && npm run repl",
+            repl: "node ./scripts/repl"
         },
         devDependencies: {
             //TODO: REPLACE WITH LIVE VERSIONS WHEN RELEASED @chalkers

--- a/templates/espruino/scripts/repl.js
+++ b/templates/espruino/scripts/repl.js
@@ -1,0 +1,6 @@
+const espruinoStrategy = require('thingssdk-espruino-strategy');
+
+const devices = require('../devices.json').devices;
+
+espruinoStrategy.utils.filterDevices(devices)
+    .forEach(espruinoStrategy.repl);

--- a/test/commands/test-new.js
+++ b/test/commands/test-new.js
@@ -45,7 +45,8 @@ describe("thingssdk new", () => {
                 private: true,
                 main: 'main.js',
                 scripts: {
-                    push: "node ./scripts/push"
+                    push: "node ./scripts/push && npm run repl",
+                    repl: "node ./scripts/repl"
                 },
                 devDependencies: {
                     //TODO: REPLACE WITH LIVE VERSIONS WHEN RELEASED @chalkers


### PR DESCRIPTION
Adds npm run repl command for Espruino devices.  @chalkers your idea worked with the node command chaining, but see the the related PR on the strategy:

thingsSDK/thingssdk-espruino-strategy#4
