### PR TITLE
Allow for local build directory

### DIFF
--- a/lib/new.js
+++ b/lib/new.js
@@ -100,6 +100,9 @@ function createFiles(options) {
         copy(path.join(templatesPath, 'dot-gitignore'), path.join(destinationPath, '.gitignore'));
         copy(path.join(templatesPath, 'dot-gitattributes'), path.join(destinationPath, '.gitattributes'));
 
+        /* Add the build directory */
+        fs.mkdirSync(path.join(destinationPath, 'build'));
+
         /* Create devices.json and finish */
         const deviceJSONOptions = { port, baud_rate, runtime, destinationPath };
         return createDevicesJSON(deviceJSONOptions);

--- a/lib/new.js
+++ b/lib/new.js
@@ -86,7 +86,9 @@ function createFiles(options) {
 
     checkForTilda(destinationPath);
 
-    return makeDirectory(destinationPath + "/scripts").then(() => {
+    return makeDirectory(path.join(destinationPath, 'scripts'))
+        .then(() => makeDirectory(path.join(destinationPath, 'build')))
+        .then(() => {
         /* Copy templates */
         fs.readdir(scriptPath, (err, files) => {
             if (err) throw err;
@@ -99,9 +101,6 @@ function createFiles(options) {
         copy(path.join(templatesPath, 'main.js'), path.join(destinationPath, 'main.js'));
         copy(path.join(templatesPath, 'dot-gitignore'), path.join(destinationPath, '.gitignore'));
         copy(path.join(templatesPath, 'dot-gitattributes'), path.join(destinationPath, '.gitattributes'));
-
-        /* Add the build directory */
-        fs.mkdirSync(path.join(destinationPath, 'build'));
 
         /* Create devices.json and finish */
         const deviceJSONOptions = { port, baud_rate, runtime, destinationPath };

--- a/templates/dot-gitignore
+++ b/templates/dot-gitignore
@@ -42,3 +42,4 @@ jspm_packages
 
 # ThingsSDK
 devices.json
+build/*

--- a/templates/espruino/scripts/push.js
+++ b/templates/espruino/scripts/push.js
@@ -1,11 +1,16 @@
 'use strict';
+const path = require('path');
 const deployer = require('thingssdk-deployer')();
 
 const espruinoStrategy = require('thingssdk-espruino-strategy');
 
 const iotPackageJson = require('../package.json');
 const devices = require('../devices.json').devices;
-const payload = { entry: iotPackageJson.main };
+const scriptsDir = path.dirname(require.main.filename);
+const payload = {
+    entry: iotPackageJson.main,
+    buildDir: path.join(scriptsDir, '..', 'build')
+};
 
 deployer.prepare(devices, payload);
 


### PR DESCRIPTION
A new strategy pattern of having a local build directory is part of the new interface.  This creates the build directory and localizes the template for use in created projects.
